### PR TITLE
Moved AutoFT JSON Documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,27 @@ After a receive sequence, the program calculates, using the distance, SNR[^1], a
 
 
 [^1] Signal to Noise Ratio
+
+
+## Auto FT8 JSON Configuration
+
+- "mongo_server": IP address or hostname of the mongodb database.  
+Type: string, Default: "localhost"
+
+- "bind_address" is the ipaddress of the sequencer.  
+Type: string, Default: "127.0.0.1"
+
+- "wsjt_port": is the UDP communication port port between the sequenser and WSJT-X.  
+Type: integer, Default: 2238
+
+- "monitor_port": is the UDP communication port between the sequenser and ftconsole.  
+This port is only for AutoFT internal use. Do not set that port in WSJT-X configuration.  
+Type: integer, Default: 2240
+
+- "call": Operator call sign.  
+This field is mandatory and shoule be set by the operator.  
+Type: string, Default: "N0CALL"
+
+- "location": Operator location. This field is used to calculate the distance and azimuth between your station and the calling station.  
+This field should be set by the operator.  
+Type: string, Default: "CM87vl"

--- a/autoft.json
+++ b/autoft.json
@@ -1,31 +1,3 @@
-#
-# AutoFT configuration
-# JSON file
-#
-#
-#  "mongo_server": IP address or hostname of the mongodb database.
-#    Type: string, Default: "localhost"
-#
-#  "bind_address" is the ipaddress of the sequencer.
-#    Type: string, Default: "127.0.0.1"
-#
-#  "wsjt_port": is the UDP communication port port between the sequenser and WSJT-X.
-#    Type: integer, Default: 2238
-#
-#  "monitor_port": is the UDP communication port between the sequenser and ftconsole.
-#    This port is only for AutoFT internal use. Do not set that port in WSJT-X configuration.
-#    Type: integer, Default: 2240
-#
-#  "call": Operator call sign.
-#    This field is mandatory and shoule be set by the operator.
-#    Type: string, Default: "N0CALL"
-#
-#  "location": Operator location. This field is used to calculate the distance and azimuth
-#    between your station and the calling station.
-#    This field should be set by the operator.
-#    Type: string, Default: "CM87vl"
-#
-
 {
     "mongo_server": "localhost",
     "bind_address": "127.0.0.1",


### PR DESCRIPTION
Removing the comments from this JSON file will allow it to be parsed correctly and allows for a central location for documentation.